### PR TITLE
Add weekly gaming time tracker web app (60 min/week)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Weekly Gaming Time Tracker</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header class="app__header">
+        <div>
+          <p class="eyebrow">Family Screen Time</p>
+          <h1>Weekly Gaming Time Tracker</h1>
+          <p class="subhead">60 minutes total per week</p>
+        </div>
+        <div class="week-info">
+          <p class="label">Week of</p>
+          <p id="week-range" class="value">—</p>
+        </div>
+      </header>
+
+      <section class="card timer-card">
+        <div class="timer-card__info">
+          <div>
+            <p class="label">Time remaining</p>
+            <p id="time-remaining" class="time">60:00</p>
+          </div>
+          <div>
+            <p class="label">Time used</p>
+            <p id="time-used" class="time">00:00</p>
+          </div>
+        </div>
+        <div class="progress">
+          <div id="progress-bar" class="progress__bar"></div>
+        </div>
+        <div class="actions">
+          <button id="toggle-session" class="primary">Start session</button>
+          <button id="reset-week" class="ghost">Reset week</button>
+        </div>
+        <p id="status" class="status">Not currently gaming.</p>
+      </section>
+
+      <section class="card">
+        <h2>Session history</h2>
+        <ul id="session-list" class="sessions"></ul>
+      </section>
+
+      <section class="tips">
+        <h3>Helpful ideas</h3>
+        <ul>
+          <li>Pause the timer during breaks or meals.</li>
+          <li>Review the history together every Sunday.</li>
+          <li>Reset the week if you plan a special gaming event.</li>
+        </ul>
+      </section>
+    </main>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,226 @@
+const WEEKLY_LIMIT_MINUTES = 60;
+const STORAGE_KEY = "gaming-time-tracker";
+
+const elements = {
+  timeRemaining: document.getElementById("time-remaining"),
+  timeUsed: document.getElementById("time-used"),
+  weekRange: document.getElementById("week-range"),
+  progressBar: document.getElementById("progress-bar"),
+  toggleSession: document.getElementById("toggle-session"),
+  resetWeek: document.getElementById("reset-week"),
+  sessionList: document.getElementById("session-list"),
+  status: document.getElementById("status"),
+};
+
+let state = loadState();
+let timerId = null;
+
+function loadState() {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  const now = new Date();
+  const week = getWeekRange(now);
+
+  if (!stored) {
+    return { weekStart: week.start.toISOString(), sessions: [], activeSession: null };
+  }
+
+  const parsed = JSON.parse(stored);
+  const storedWeekStart = new Date(parsed.weekStart);
+  if (storedWeekStart.toDateString() !== week.start.toDateString()) {
+    return { weekStart: week.start.toISOString(), sessions: [], activeSession: null };
+  }
+
+  return parsed;
+}
+
+function saveState() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+function getWeekRange(date) {
+  const day = date.getDay();
+  const diff = (day === 0 ? -6 : 1) - day; // Monday start
+  const start = new Date(date);
+  start.setDate(date.getDate() + diff);
+  start.setHours(0, 0, 0, 0);
+
+  const end = new Date(start);
+  end.setDate(start.getDate() + 6);
+  end.setHours(23, 59, 59, 999);
+
+  return { start, end };
+}
+
+function formatWeekRange() {
+  const week = getWeekRange(new Date(state.weekStart));
+  const options = { month: "short", day: "numeric" };
+  return `${week.start.toLocaleDateString(undefined, options)} - ${week.end.toLocaleDateString(undefined, options)}`;
+}
+
+function formatDuration(totalSeconds) {
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+function calculateUsedSeconds() {
+  const sessionSeconds = state.sessions.reduce((total, session) => total + session.duration, 0);
+  if (!state.activeSession) {
+    return sessionSeconds;
+  }
+  const activeStart = new Date(state.activeSession.startedAt);
+  const now = new Date();
+  return sessionSeconds + Math.max(0, Math.floor((now - activeStart) / 1000));
+}
+
+function updateUI() {
+  const usedSeconds = calculateUsedSeconds();
+  const limitSeconds = WEEKLY_LIMIT_MINUTES * 60;
+  const remainingSeconds = Math.max(0, limitSeconds - usedSeconds);
+  const progressPercent = Math.min(100, (usedSeconds / limitSeconds) * 100);
+
+  elements.timeUsed.textContent = formatDuration(usedSeconds);
+  elements.timeRemaining.textContent = formatDuration(remainingSeconds);
+  elements.weekRange.textContent = formatWeekRange();
+  elements.progressBar.style.width = `${progressPercent}%`;
+
+  if (state.activeSession) {
+    elements.toggleSession.textContent = "End session";
+    elements.toggleSession.dataset.running = "true";
+    elements.status.textContent = "Gaming time is running. Remember to pause for breaks.";
+  } else {
+    elements.toggleSession.textContent = "Start session";
+    elements.toggleSession.dataset.running = "false";
+    elements.status.textContent = "Not currently gaming.";
+  }
+
+  renderSessions();
+}
+
+function renderSessions() {
+  elements.sessionList.innerHTML = "";
+  if (state.sessions.length === 0 && !state.activeSession) {
+    const empty = document.createElement("li");
+    empty.className = "session-item";
+    empty.textContent = "No sessions logged yet.";
+    elements.sessionList.appendChild(empty);
+    return;
+  }
+
+  const sessions = [...state.sessions];
+  if (state.activeSession) {
+    sessions.push({
+      startedAt: state.activeSession.startedAt,
+      duration: Math.max(0, Math.floor((new Date() - new Date(state.activeSession.startedAt)) / 1000)),
+      active: true,
+    });
+  }
+
+  sessions.reverse().forEach((session) => {
+    const item = document.createElement("li");
+    item.className = "session-item";
+    const start = new Date(session.startedAt);
+    const label = start.toLocaleString(undefined, {
+      weekday: "short",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+    item.innerHTML = `
+      <div>
+        <div>${label}${session.active ? " • In progress" : ""}</div>
+        <small>${start.toLocaleDateString()}</small>
+      </div>
+      <span>${formatDuration(session.duration)}</span>
+    `;
+    elements.sessionList.appendChild(item);
+  });
+}
+
+function startSession() {
+  const usedSeconds = calculateUsedSeconds();
+  const limitSeconds = WEEKLY_LIMIT_MINUTES * 60;
+  if (usedSeconds >= limitSeconds) {
+    elements.status.textContent = "Weekly limit reached. Reset the week to start over.";
+    return;
+  }
+
+  state.activeSession = { startedAt: new Date().toISOString() };
+  saveState();
+  startTimer();
+  updateUI();
+}
+
+function endSession() {
+  if (!state.activeSession) {
+    return;
+  }
+
+  const now = new Date();
+  const startedAt = new Date(state.activeSession.startedAt);
+  const duration = Math.max(0, Math.floor((now - startedAt) / 1000));
+  state.sessions.push({ startedAt: state.activeSession.startedAt, duration });
+  state.activeSession = null;
+  saveState();
+  stopTimer();
+  updateUI();
+}
+
+function resetWeek() {
+  const confirmReset = window.confirm("Reset the week and clear all sessions?");
+  if (!confirmReset) {
+    return;
+  }
+  const week = getWeekRange(new Date());
+  state = { weekStart: week.start.toISOString(), sessions: [], activeSession: null };
+  saveState();
+  stopTimer();
+  updateUI();
+}
+
+function startTimer() {
+  if (timerId) {
+    return;
+  }
+  timerId = window.setInterval(() => {
+    const usedSeconds = calculateUsedSeconds();
+    if (usedSeconds >= WEEKLY_LIMIT_MINUTES * 60) {
+      endSession();
+      elements.status.textContent = "Weekly limit reached. Great job sticking to the plan!";
+      return;
+    }
+    updateUI();
+  }, 1000);
+}
+
+function stopTimer() {
+  if (timerId) {
+    clearInterval(timerId);
+    timerId = null;
+  }
+}
+
+function initialize() {
+  const week = getWeekRange(new Date());
+  const storedWeekStart = new Date(state.weekStart);
+  if (storedWeekStart.toDateString() !== week.start.toDateString()) {
+    state = { weekStart: week.start.toISOString(), sessions: [], activeSession: null };
+    saveState();
+  }
+
+  if (state.activeSession) {
+    startTimer();
+  }
+
+  elements.toggleSession.addEventListener("click", () => {
+    if (state.activeSession) {
+      endSession();
+    } else {
+      startSession();
+    }
+  });
+
+  elements.resetWeek.addEventListener("click", resetWeek);
+  updateUI();
+}
+
+initialize();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,191 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background-color: #f5f7fb;
+  color: #1f2a44;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 40px 20px 60px;
+}
+
+.app {
+  width: min(900px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.app__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 12px;
+  font-weight: 600;
+  color: #52607c;
+  margin: 0 0 8px;
+}
+
+.subhead {
+  margin: 8px 0 0;
+  color: #52607c;
+}
+
+.week-info {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 16px 20px;
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
+  min-width: 180px;
+}
+
+.label {
+  text-transform: uppercase;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  margin: 0 0 6px;
+  color: #6a7692;
+}
+
+.value {
+  font-weight: 600;
+  margin: 0;
+}
+
+.card {
+  background: #ffffff;
+  border-radius: 20px;
+  padding: 24px;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+}
+
+.timer-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.timer-card__info {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+}
+
+.time {
+  font-size: 36px;
+  font-weight: 700;
+  margin: 0;
+}
+
+.progress {
+  width: 100%;
+  height: 12px;
+  background: #e5e9f2;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress__bar {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, #4f7df5, #6bdcff);
+  transition: width 0.4s ease;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  padding: 12px 22px;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+button.primary {
+  background: #1f4dd7;
+  color: #ffffff;
+  box-shadow: 0 12px 24px rgba(31, 77, 215, 0.25);
+}
+
+button.primary[data-running="true"] {
+  background: #d7195c;
+  box-shadow: 0 12px 24px rgba(215, 25, 92, 0.25);
+}
+
+button.ghost {
+  background: transparent;
+  border: 1px solid #d2d8e6;
+  color: #4b5d7b;
+}
+
+.status {
+  margin: 0;
+  color: #52607c;
+}
+
+.sessions {
+  list-style: none;
+  padding: 0;
+  margin: 16px 0 0;
+  display: grid;
+  gap: 12px;
+}
+
+.session-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  background: #f6f8fe;
+  border-radius: 12px;
+  color: #2c3850;
+}
+
+.session-item span {
+  font-weight: 600;
+}
+
+.tips {
+  padding: 0 8px;
+}
+
+.tips h3 {
+  margin-bottom: 8px;
+}
+
+.tips ul {
+  margin: 0;
+  padding-left: 18px;
+  color: #52607c;
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 24px 16px 40px;
+  }
+
+  .time {
+    font-size: 30px;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight local web app to enforce a 60-minute weekly gaming limit.
- Let guardians start/end sessions and review session history with a visible progress indicator.
- Persist sessions across reloads using browser storage and automatically reset at the start of a new week.
- Deliver a responsive, mobile-friendly UI so the tracker is easy to use on phones and desktops.

### Description
- Add `index.html` which includes the UI for time remaining, time used, progress bar, session controls, and session history.
- Add `styles.css` to style the app responsively and include visual states such as the running state via `data-running`.
- Add `script.js` implementing session tracking with `localStorage`, the `WEEKLY_LIMIT_MINUTES = 60` constant, start/end session logic, weekly reset logic, and a per-second timer to update the UI.
- Ensure active sessions render in the history and that sessions are automatically ended when the weekly limit is reached.

### Testing
- Launched a local static server with `python -m http.server 8000` and confirmed the site served successfully.
- Ran a Playwright script that loaded `http://127.0.0.1:8000` and captured a full-page screenshot, which completed successfully.
- No automated unit tests were added for this change.
- Manual interaction can be used to validate start/end/reset behavior and persistence across reloads.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bc47541288328aa766d6f4d3107e6)